### PR TITLE
Add nav Archives submenu to collapse older digests

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,0 +1,41 @@
+<header class="site-header" role="banner">
+  <div class="wrapper">
+    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+
+    <nav class="site-nav">
+      <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+      <label for="nav-trigger">
+        <span class="menu-icon">
+          <svg viewBox="0 0 18 15" width="18px" height="15px">
+            <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.303,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.031C17.335,0,18,0.665,18,1.484L18,0z"/>
+            <path d="M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484 h15.031C17.335,6.031,18,6.696,18,7.516L18,0z"/>
+            <path d="M18,13.516C18,14.335,17.335,15,16.516,15H1.484C0.665,15,0,14.335,0,13.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,12.031,18,12.696,18,13.516L18,0z"/>
+          </svg>
+        </span>
+      </label>
+
+      <div class="trigger">
+        {%- assign digest_pages = site.pages | where_exp: "p", "p.path contains 'digests/'" | sort: "date" | reverse -%}
+        {%- assign recent_digests = digest_pages | slice: 0, 3 -%}
+        {%- assign archive_digests = digest_pages | slice: 3, 100 -%}
+
+        {%- for p in recent_digests -%}
+          <a class="page-link" href="{{ p.url | relative_url }}">{{ p.title | escape }}</a>
+        {%- endfor -%}
+
+        {%- if archive_digests.size > 0 -%}
+          <div class="nav-dropdown">
+            <button class="page-link nav-dropdown-toggle" aria-haspopup="true">Archive &#9662;</button>
+            <div class="nav-dropdown-menu">
+              {%- for p in archive_digests -%}
+                <a class="nav-dropdown-item" href="{{ p.url | relative_url }}">{{ p.title | escape }}</a>
+              {%- endfor -%}
+            </div>
+          </div>
+        {%- endif -%}
+
+        <a class="page-link" href="{{ "/" | relative_url }}">Home</a>
+      </div>
+    </nav>
+  </div>
+</header>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,0 +1,82 @@
+---
+---
+
+@import "minima";
+
+.nav-dropdown {
+  display: inline-block;
+  position: relative;
+}
+
+.nav-dropdown-toggle {
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: inherit;
+  cursor: pointer;
+  padding: 0;
+  color: #111111;
+
+  &:hover {
+    color: #2a7ae2;
+  }
+}
+
+.nav-dropdown-menu {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: #fdfdfd;
+  border: 1px solid #e8e8e8;
+  border-radius: 4px;
+  padding: 6px 0;
+  min-width: 220px;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.nav-dropdown:hover .nav-dropdown-menu,
+.nav-dropdown:focus-within .nav-dropdown-menu {
+  display: block;
+}
+
+.nav-dropdown-item {
+  display: block;
+  padding: 7px 16px;
+  color: #111111;
+  text-decoration: none;
+  font-size: 16px;
+  white-space: nowrap;
+
+  &:hover {
+    background: #f0f0f0;
+    color: #2a7ae2;
+  }
+}
+
+// On mobile the nav is shown in vertical stack — flatten dropdown into the flow
+@media screen and (max-width: 600px) {
+  .nav-dropdown {
+    display: block;
+  }
+
+  .nav-dropdown-toggle {
+    display: block;
+    padding: 5px 0;
+    font-weight: bold;
+  }
+
+  .nav-dropdown-menu {
+    display: block;
+    position: static;
+    border: none;
+    box-shadow: none;
+    padding: 0 0 0 12px;
+  }
+
+  .nav-dropdown-item {
+    font-size: 16px;
+    padding: 4px 0;
+  }
+}


### PR DESCRIPTION
Show the 3 most recent digests directly in the header nav; remaining digests are grouped under an "Archive" hover dropdown. Custom header.html overrides the minima default, and style.scss adds dropdown styles (with a mobile fallback that flattens the menu into the vertical stack).

https://claude.ai/code/session_01625AznGy8wfmBjNpXTGiyN