### PR TITLE
Auto-merge digest PRs on creation

### DIFF
--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -63,3 +63,4 @@ jobs:
             --body "Weekly digest for $(date +%Y-%m-%d). Review and merge to publish to GitHub Pages." \
             --base primary \
             --head "$BRANCH"
+          gh pr merge "$BRANCH" --auto --merge


### PR DESCRIPTION
Adds `gh pr merge --auto --merge` immediately after the digest PR is created, so future digests merge themselves without manual intervention.

Note: GitHub repository settings must have "Allow auto-merge" enabled for this to work — it's in Settings → General → Pull Requests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7WRsze2qktg7BqbDe3guB)_