### PR TITLE
Fix digest auto-merge failure and collapse nav via archive page

### DIFF
--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -63,4 +63,7 @@ jobs:
             --body "Weekly digest for $(date +%Y-%m-%d). Review and merge to publish to GitHub Pages." \
             --base primary \
             --head "$BRANCH"
-          gh pr merge "$BRANCH" --auto --merge
+          # --auto only works when merge is blocked (e.g. required checks pending).
+          # With no branch protection the PR is immediately "clean" and GitHub
+          # rejects enabling auto-merge, so fall back to merging directly.
+          gh pr merge "$BRANCH" --auto --merge || gh pr merge "$BRANCH" --merge

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,5 +2,9 @@ title: Claude Code Intelligence Digest
 description: Automated weekly digest of Claude Code ecosystem updates
 theme: minima
 baseurl: /claude-code-digest
+# Only these pages appear in the header nav; digest pages live under /archive
+header_pages:
+  - index.md
+  - archive.md
 kramdown:
   toc_levels: "2"

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Archive
+---
+
+# Digest Archive
+
+All published digests, newest first.
+
+{% assign digests = site.pages | where_exp: "p", "p.dir == '/digests/'" | sort: "date" | reverse %}
+{% for d in digests %}- [{{ d.date | date: "%d %b %Y" }}]({{ d.url | relative_url }}){% if d.special_edition %} — Special Edition{% endif %}
+{% endfor %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,28 +11,10 @@ Automated weekly digest of Claude Code ecosystem updates, community tools, and r
 
 **[05 Jul 2026](digests/2026-07-05)** — View the latest digest.
 
-## Archive
+## Recent
 
 - [05 Jul 2026](digests/2026-07-05)
 - [28 Jun 2026](digests/2026-06-28)
 - [21 Jun 2026](digests/2026-06-21)
-- [14 Jun 2026](digests/2026-06-14)
-- [07 Jun 2026](digests/2026-06-07)
-- [31 May 2026](digests/2026-05-31)
-- [24 May 2026](digests/2026-05-24)
-- [17 May 2026](digests/2026-05-17)
-- [10 May 2026](digests/2026-05-10)
-- [03 May 2026](digests/2026-05-03)
-- [26 Apr 2026](digests/2026-04-26)
-- [19 Apr 2026](digests/2026-04-19)
-- [12 Apr 2026](digests/2026-04-12)
-- [05 Apr 2026](digests/2026-04-05)
-- [2026-04-04-source-leak](digests/2026-04-04-source-leak)
-- [29 Mar 2026](digests/2026-03-29)
-- [22 Mar 2026](digests/2026-03-22)
-- [15 Mar 2026](digests/2026-03-15)
-- [08 Mar 2026](digests/2026-03-08)
-- [01 Mar 2026](digests/2026-03-01)
-- [22 Feb 2026](digests/2026-02-22)
-- [16 Feb 2026](digests/2026-02-16)
-- [10 Feb 2026](digests/2026-02-10)
+
+[Browse the full archive →](archive)

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -71,21 +71,28 @@ items: {digest['items_included']}
     return out_path
 
 
+RECENT_DIGESTS_ON_INDEX = 3
+
+
 def update_index(digest_date: str) -> None:
-    """Rewrite docs/index.md with latest digest and archive list."""
+    """Rewrite docs/index.md with the latest digest and a short recent list.
+
+    Older digests are not listed here; docs/archive.md renders the full
+    list at build time via Liquid, so it needs no regeneration.
+    """
     dt = datetime.strptime(digest_date, "%Y-%m-%d")
 
     # Collect all existing digest files
     digest_files = sorted(DIGESTS_DIR.glob("*.md"), reverse=True)
-    archive_lines = []
-    for f in digest_files:
+    recent_lines = []
+    for f in digest_files[:RECENT_DIGESTS_ON_INDEX]:
         d = f.stem  # YYYY-MM-DD
         try:
             fdt = datetime.strptime(d, "%Y-%m-%d")
             label = fdt.strftime("%d %b %Y")
         except ValueError:
             label = d
-        archive_lines.append(f"- [{label}](digests/{d})")
+        recent_lines.append(f"- [{label}](digests/{d})")
 
     index_content = f"""---
 layout: default
@@ -100,14 +107,16 @@ Automated weekly digest of Claude Code ecosystem updates, community tools, and r
 
 **[{dt.strftime('%d %b %Y')}](digests/{digest_date})** — View the latest digest.
 
-## Archive
+## Recent
 
-{chr(10).join(archive_lines) if archive_lines else '_No digests yet._'}
+{chr(10).join(recent_lines) if recent_lines else '_No digests yet._'}
+
+[Browse the full archive →](archive)
 """
 
     index_path = DOCS_DIR / "index.md"
     index_path.write_text(index_content, encoding="utf-8")
-    logger.info("Updated index.md with %d archive entries", len(archive_lines))
+    logger.info("Updated index.md with %d recent entries", len(recent_lines))
 
 
 def close_inbox_issues(items: list, digest_date: str) -> None:


### PR DESCRIPTION
- digest.yml: 'gh pr merge --auto' fails with 'Pull request is in clean
  status' when nothing blocks the merge (no required checks), which has
  failed every weekly run since #32. Fall back to a direct merge.
- Replace the ever-growing header nav with an Archive page: header_pages
  limits the nav to Home + Archive, and archive.md lists all digests via
  Liquid at build time (no regeneration needed). Simpler alternative to
  PR #23, per review feedback there.
- publish.py now writes index.md with the latest digest plus the 3 most
  recent, linking to the archive instead of listing everything.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013GQG7cA2JiciALyEsbuPVf